### PR TITLE
Podcast preload=none, prev-next to bottom

### DIFF
--- a/Newspack-Podcasts-1.2.1/includes/class-newspack-podcasts-frontend.php
+++ b/Newspack-Podcasts-1.2.1/includes/class-newspack-podcasts-frontend.php
@@ -110,7 +110,7 @@ class Newspack_Podcasts_Frontend {
 		ob_start();
 		?>
 <!-- wp:audio {"className":"newspack-podcast-player"} -->
-<figure class="wp-block-audio newspack-podcast-player"><audio controls src="<?php echo esc_url( $podcast_url ); ?>"></audio></figure>
+<figure class="wp-block-audio newspack-podcast-player"><audio controls preload="none" src="<?php echo esc_url( $podcast_url ); ?>"></audio></figure>
 <!-- /wp:audio -->
 		<?php
 

--- a/Newspack-Podcasts-1.2.1/includes/class-newspack-podcasts-frontend.php
+++ b/Newspack-Podcasts-1.2.1/includes/class-newspack-podcasts-frontend.php
@@ -57,10 +57,10 @@ class Newspack_Podcasts_Frontend {
 			return $content;
 		}
 
-		$markup  = $this->get_player_html();
-		$markup .= $this->get_next_prev_links_html();
+		$player  = $this->get_player_html();
+		$next_prev = $this->get_next_prev_links_html();
 
-		return $markup . $content;
+		return $player . $content . $next_prev;
 	}
 
 	/**
@@ -195,4 +195,3 @@ class Newspack_Podcasts_Frontend {
 	}
 }
 Newspack_Podcasts_Frontend::instance();
-


### PR DESCRIPTION
Adds an attribute preload="none" to our podcast players to be inline with what PRX recommends. Splits the player and the previous/next buttons and places the prev/next buttons after the episode body.